### PR TITLE
Fix hubot slack v4 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.3-3",
+  "version": "0.1.3-4",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.3-2",
+  "version": "0.1.3-3",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.3-4",
+  "version": "0.1.3-5",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.3-0",
+  "version": "0.1.3-1",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.2",
+  "version": "0.1.3-0",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.3-1",
+  "version": "0.1.3-2",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hackbot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Andrew Seward <abseward@googlemail.com>",
   "contributors": [
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,6 @@ const Config = {
     required: false,
     default: [],
     loader: (value: string) => value.split(','),
-    value: <string[]> undefined,
   },
 };
 

--- a/src/custom_typings/hubot-slack.d.ts
+++ b/src/custom_typings/hubot-slack.d.ts
@@ -1,6 +1,22 @@
 declare module 'hubot-slack' {
   import { Adapter, Robot as Hubot, Response as HubotResponse, IEnvelope as HubotEnvelope } from 'hubot';
-  import { MemoryDataStore, User as SlackUser } from '@slack/client';
+  import { MemoryDataStore, User as SlackUser, RtmClient, WebClient } from '@slack/client';
+
+  interface SlackClient {
+    robot: Robot;
+
+    rtm: RtmClient;
+    web: WebClient;
+    format: SlackFormatter;
+    listeners: any[];
+
+    connect(): void;
+    on(name: string, callback: (arg: any) => void): void;
+    disconnect(): void;
+    setTopic(id: string, topic: string): void;
+    send(envelope: Envelope, message: string): void;
+    send(envelope: Envelope, message: ICustomMessageData): void;
+  }
 
   // see https://api.slack.com/docs/attachments
   // also https://api.slack.com/docs/formatting/builder
@@ -67,7 +83,7 @@ declare module 'hubot-slack' {
     user: SlackUser;
   }
 
-  export interface Response extends HubotResponse {
+  interface Response extends HubotResponse {
     envelope: Envelope & HubotEnvelope;
 
     send(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
@@ -84,5 +100,9 @@ declare module 'hubot-slack' {
     reply(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
   }
 
-  export function use(robot: Hubot): SlackBot;
+  interface SlackFormatter {
+
+  }
+
+  function use(robot: Hubot): SlackBot;
 }

--- a/src/custom_typings/hubot-slack.d.ts
+++ b/src/custom_typings/hubot-slack.d.ts
@@ -1,6 +1,6 @@
-declare module "hubot-slack" {
-  import { Adapter, Robot as Hubot, Response as HubotResponse, IEnvelope } from 'hubot';
-  import { MemoryDataStore } from '@slack/client';
+declare module 'hubot-slack' {
+  import { Adapter, Robot as Hubot, Response as HubotResponse, IEnvelope as HubotEnvelope } from 'hubot';
+  import { MemoryDataStore, User as SlackUser } from '@slack/client';
 
   // see https://api.slack.com/docs/attachments
   // also https://api.slack.com/docs/formatting/builder
@@ -50,20 +50,28 @@ declare module "hubot-slack" {
     icon_emoji?: string;
   }
 
-  interface SlackBot extends Adapter {
-    client: {
-      rtm: {
-        dataStore: MemoryDataStore;
-      }
+  interface SlackBotClient {
+    rtm: {
+      dataStore: MemoryDataStore;
     }
+  }
 
-    send(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
-    reply(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
+  interface SlackBot extends Adapter {
+    client: SlackBotClient;
+
+    send(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
+    reply(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
+  }
+
+  interface Envelope {
+    user: SlackUser;
   }
 
   export interface Response extends HubotResponse {
-    send(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
-    reply(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
+    envelope: Envelope & HubotEnvelope;
+
+    send(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
+    reply(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
   }
 
   interface Robot extends Hubot {
@@ -72,8 +80,8 @@ declare module "hubot-slack" {
     respond(regex: RegExp, options: any, callback: (res: Response) => void): void;
     respond(regex: RegExp, callback: (res: Response) => void): void;
     error(handler: (err: Error, res: Response) => void): void;
-    send(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
-    reply(envelope: IEnvelope, ...messages: ICustomMessageData[]): void;
+    send(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
+    reply(envelope: HubotEnvelope, ...messages: ICustomMessageData[]): void;
   }
 
   export function use(robot: Hubot): SlackBot;

--- a/src/custom_typings/hubot-slack.d.ts
+++ b/src/custom_typings/hubot-slack.d.ts
@@ -67,9 +67,7 @@ declare module 'hubot-slack' {
   }
 
   interface SlackBotClient {
-    rtm: {
-      dataStore: MemoryDataStore;
-    }
+    rtm: RtmClient;
   }
 
   interface SlackBot extends Adapter {

--- a/src/custom_typings/hubot-test-helper.d.ts
+++ b/src/custom_typings/hubot-test-helper.d.ts
@@ -13,7 +13,7 @@ declare module 'hubot-test-helper' {
     }
 
     interface Helper {
-      new (scriptsPaths: string): Helper;
+      new (scriptsPaths: string | string[]): Helper;
       createRoom(options?: CreateRoomOptions): Room;
     }
 

--- a/src/custom_typings/hubot.d.ts
+++ b/src/custom_typings/hubot.d.ts
@@ -23,14 +23,14 @@ declare module "hubot" {
     message?: Message;
   }
 
-  export class User {
+  class User {
     id: string;
     name: string;
     room: string;
   }
 
-  export class Message {
-    constructor (user: User);
+  class Message {
+    constructor(user: User);
 
     user: User;
     text: string;
@@ -39,15 +39,15 @@ declare module "hubot" {
     done: boolean;
   }
 
-  export class EnterMessage extends Message { }
-  export class LeaveMessage extends Message { }
-  export class TopicMessage extends Message { }
-  export class TextMessage extends Message { }
-  export class CatchAllMessage extends Message {
+  class EnterMessage extends Message { }
+  class LeaveMessage extends Message { }
+  class TopicMessage extends Message { }
+  class TextMessage extends Message { }
+  class CatchAllMessage extends Message {
     message: Message;
   }
 
-  export class Response {
+  class Response {
     robot: Robot;
     match: string[];
     message: Message;
@@ -59,22 +59,30 @@ declare module "hubot" {
     reply(...strings: string[]): void;
   }
 
-  export interface IBrain {
+  class Listener {
+
+  }
+
+  class TextListener {
+
+  }
+
+  interface IBrain {
     get(key: string): any;
     set(key: string, value: any): IBrain;
   }
 
-  export interface UserData {
+  interface UserData {
     email_address: string;
     name: string;
     id: string;
   }
 
-  export interface BrainData {
-    users: { [userId: string] : UserData }
+  interface BrainData {
+    users: { [userId: string]: UserData }
   }
 
-  export class Brain implements IBrain {
+  class Brain implements IBrain {
     constructor(robot: Robot);
 
     users(): { [id: string]: User; };
@@ -90,7 +98,7 @@ declare module "hubot" {
     data: BrainData;
   }
 
-  export class Adapter {
+  class Adapter {
     constructor(robot: Robot);
 
     send(envelope: IEnvelope, ...messages: string[]): void;
@@ -109,7 +117,7 @@ declare module "hubot" {
     debug(...msg: any[]): void;
   }
 
-  export class Robot {
+  class Robot {
     adapter: Adapter;
     brain: Brain;
     router: ExpressApp;
@@ -129,5 +137,8 @@ declare module "hubot" {
     on(event: string, listener: (arg: any) => void): void;
     send(envelope: IEnvelope, ...messages: string[]): void;
     reply(envelope: IEnvelope, ...messages: Message[]): void;
+
+    loadFile(path: string, file: string): void;
+    load(path: string): void;
   }
 }

--- a/src/custom_typings/slack-client.d.ts
+++ b/src/custom_typings/slack-client.d.ts
@@ -200,7 +200,7 @@ declare module "@slack/client" {
     over_integrations_limit: boolean;
   }
 
-  interface MemoryDataStore {
+  class MemoryDataStore {
     clear(): void;
 
     getUserById(userId: string): User;

--- a/src/custom_typings/slack-client.d.ts
+++ b/src/custom_typings/slack-client.d.ts
@@ -240,4 +240,19 @@ declare module "@slack/client" {
     removeBot(bot: Bot): void;
     removeTeam(team: Team): void;
   }
+
+  class RtmClient {}
+
+  class WebClient {}
+
+  class IncomingWebhook {}
+
+  class LegacyRtmClient {}
+
+  var CLIENT_EVENTS: {
+    WEB: string;
+    RTM: string;
+  };
+  var RTM_EVENTS: {};
+  var RTM_MESSAGE_SUBTYPES: {};
 }

--- a/src/custom_typings/slack-client.d.ts
+++ b/src/custom_typings/slack-client.d.ts
@@ -241,9 +241,51 @@ declare module "@slack/client" {
     removeTeam(team: Team): void;
   }
 
-  class RtmClient {}
+  interface ClientOptions {
+    socketFn: (socketUrl: string, opts: { proxyURL?: string }) => any;
+    dataStore: any;
+    autoReconnect: boolean;
+    maxReconnectionAttempts: number;
+    reconnectionBackoff: number;
+    wsPingInterval: number;
+    maxPongInterval: number;
+    logLevel: string;
+    logger: (logLevel: string, logString: string) => void;
+  }
 
-  class WebClient {}
+  interface BaseAPIClient {
+    slackAPIUrl: string;
+    userAgent: string;
+    dataStore: MemoryDataStore;
+    transport: (args: any, cb: Function) => void;
+
+    emit(...args: any[]): void;
+    registerDataStore(dataStore: any): void;
+  }
+
+  class RtmClient implements BaseAPIClient {
+    constructor(token: string, opts: ClientOptions);
+
+    slackAPIUrl: string;
+    userAgent: string;
+    dataStore: MemoryDataStore;
+    transport: (args: any, cb: Function) => void;
+
+    emit(...args: any[]): void;
+    registerDataStore(dataStore: any): void;
+  }
+
+  class WebClient implements BaseAPIClient {
+    constructor(token: string, opts: ClientOptions);
+
+    slackAPIUrl: string;
+    userAgent: string;
+    dataStore: MemoryDataStore;
+    transport: (args: any, cb: Function) => void;
+
+    emit(...args: any[]): void;
+    registerDataStore(dataStore: any): void;
+  }
 
   class IncomingWebhook {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ import TellMeAboutTeamScript from './scripts/tell_me_about_team.script';
 function load(robot: RobotWithClient) {
   loadConfig(robot.logger.error.bind(robot.logger));
 
-  robot.logger.info(`HACKBOT_ERROR_CHANNEL set to ${Config.HACKBOT_ERROR_CHANNEL}`);
-  robot.logger.info(`HACKBOT_API_URL set to ${Config.HACKBOT_API_URL}`);
+  robot.logger.info(`HACKBOT_ERROR_CHANNEL set to ${Config.HACKBOT_ERROR_CHANNEL.value}`);
+  robot.logger.info(`HACKBOT_API_URL set to ${Config.HACKBOT_API_URL.value}`);
 
   robot.client = new Client(Config.HACKBOT_API_URL.value, Config.HACKBOT_API_PASSWORD.value, robot);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ import TellMeAboutTeamScript from './scripts/tell_me_about_team.script';
 function load(robot: RobotWithClient) {
   loadConfig(robot.logger.error.bind(robot.logger));
 
-  robot.logger.info(`HACKBOT_ERROR_CHANNEL set to ${Config.HACKBOT_ERROR_CHANNEL.value}`);
-  robot.logger.info(`HACKBOT_API_URL set to ${Config.HACKBOT_API_URL.value}`);
+  robot.logger.debug(`HACKBOT_ERROR_CHANNEL set to ${Config.HACKBOT_ERROR_CHANNEL.value}`);
+  robot.logger.debug(`HACKBOT_API_URL set to ${Config.HACKBOT_API_URL.value}`);
 
   robot.client = new Client(Config.HACKBOT_API_URL.value, Config.HACKBOT_API_PASSWORD.value, robot);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ import TellMeAboutTeamScript from './scripts/tell_me_about_team.script';
 function load(robot: RobotWithClient) {
   loadConfig(robot.logger.error.bind(robot.logger));
 
+  robot.logger.info(`HACKBOT_ERROR_CHANNEL set to ${Config.HACKBOT_ERROR_CHANNEL}`);
+  robot.logger.info(`HACKBOT_API_URL set to ${Config.HACKBOT_API_URL}`);
+
   robot.client = new Client(Config.HACKBOT_API_URL.value, Config.HACKBOT_API_PASSWORD.value, robot);
 
   ErrorScript(robot);

--- a/src/scripts/add_username_to_my_team.script.ts
+++ b/src/scripts/add_username_to_my_team.script.ts
@@ -1,4 +1,4 @@
-import { UserData, Response } from 'hubot';
+import { Response } from 'hubot';
 import { RobotWithClient } from '../hackbot';
 
 function addUserToTeam(
@@ -28,31 +28,19 @@ export default (robot: RobotWithClient) => {
 
   robot.respond(/add @([a-z0-9.\-_]+)\s+to my team/, response => {
     const otherUsername = response.match[1];
-    const userId = response.message.user.id;
+    const dataStore = robot.adapter.client.rtm.dataStore;
+    const user = dataStore.getUserById(response.message.user.id);
 
-    robot
-      .client
-      .getUser(userId)
+    robot.client
+      .getUser(user.id)
       .then(userResponse => {
         if (userResponse.user.team.id === undefined) {
           return response.reply(`I would, but you're not in a team...`);
         }
 
         const teamId = userResponse.user.team.id;
-
-        let otherUser: UserData;
-        const users = robot.brain.data.users;
-        for (let _userId in robot.brain.data.users) {
-          if (robot.brain.data.users.hasOwnProperty(_userId)) {
-            const user = users[_userId];
-            if (user.name === otherUsername) {
-              otherUser = user;
-              break;
-            }
-          }
-        }
-
-        const emailAddress = robot.brain.data.users[userId].email_address;
+        const otherUser = dataStore.getUserByName(otherUsername);
+        const emailAddress = user.profile.email;
 
         return robot.client.getUser(otherUser.id)
           .then(_userResponse => {

--- a/src/scripts/create_team.script.ts
+++ b/src/scripts/create_team.script.ts
@@ -3,20 +3,20 @@ import { RobotWithClient } from '../hackbot';
 export default (robot: RobotWithClient) => {
 
   robot.respond(/create team (.*)/i, (response) => {
-    const userId = response.message.user.id;
+    const user = robot.adapter.client.rtm.dataStore.getUserById(response.message.user.id);
     const userName = response.message.user.name;
     const teamName = response.match[1];
 
-    robot.client.getUser(userId)
+    robot.client.getUser(user.id)
       .then((res) => {
 
-        const emailAddress = robot.brain.data.users[userId].email_address;
+        const emailAddress = user.profile.email;
 
         if (res.statusCode === 404) {
-          return robot.client.createUser(userId, userName, emailAddress)
+          return robot.client.createUser(user.id, userName, emailAddress)
             .then(createUserResponse => {
               if (createUserResponse.ok) {
-                return robot.client.createTeam(teamName, userId, emailAddress)
+                return robot.client.createTeam(teamName, user.id, emailAddress)
                   .then(createTeamResponse => {
                     if (createTeamResponse.ok) {
                       return response.reply(`Welcome to team ${teamName}!`);
@@ -41,7 +41,7 @@ export default (robot: RobotWithClient) => {
           return response.reply(`You're already a member of ${res.user.team.name}!`);
         }
 
-        return robot.client.createTeam(teamName, userId, emailAddress)
+        return robot.client.createTeam(teamName, user.id, emailAddress)
           .then(createTeamResponse => {
             if (createTeamResponse.ok) {
               return response.reply(`Welcome to team ${teamName}!`);

--- a/src/scripts/leave_my_team.script.ts
+++ b/src/scripts/leave_my_team.script.ts
@@ -3,17 +3,17 @@ import { RobotWithClient } from '../hackbot';
 export default (robot: RobotWithClient) => {
 
   robot.respond(/leave my team/i, response => {
-    const userId = response.message.user.id;
+    const user = robot.adapter.client.rtm.dataStore.getUserById(response.message.user.id);
 
-    robot.client.getUser(userId)
+    robot.client.getUser(user.id)
       .then(res => {
         if (!res.ok || res.user.team.id === undefined) {
           return response.reply(`You're not in a team! :goberserk:`);
         }
 
-        const emailAddress = robot.brain.data.users[userId].email_address;
+        const emailAddress = user.profile.email;
 
-        return robot.client.removeTeamMember(res.user.team.id, userId, emailAddress)
+        return robot.client.removeTeamMember(res.user.team.id, user.id, emailAddress)
           .then(removeTeamMemberResponse => {
             if (removeTeamMemberResponse.ok) {
               return response.reply(`OK, you've been removed from team "${res.user.team.name}"`);

--- a/src/scripts/my_id.script.ts
+++ b/src/scripts/my_id.script.ts
@@ -2,10 +2,8 @@ import { Robot } from 'hubot-slack';
 
 export default (robot: Robot) => {
 
-  robot.respond(/my id/i, (response) => {
-    const userId = response.envelope.user.id;
-    const dataStore = robot.adapter.client.rtm.dataStore;
-    const user = dataStore.getUserById(userId);
+  robot.respond(/who am i/i, (response) => {
+    const user = response.envelope.user;
 
     if (user) {
       const msg = JSON.stringify(user, null, 2);
@@ -22,12 +20,12 @@ export default (robot: Robot) => {
     }
   });
 
-  robot.respond(/whois (.+)/i, (response) => {
+  robot.respond(/who is (.+)/i, (response) => {
     const dataStore = robot.adapter.client.rtm.dataStore;
 
     const userId = response.envelope.user.id;
     if (!dataStore.getUserById(userId).is_admin) {
-      return response.reply('Only admins can use the `whois` command');
+      return response.reply('Only admins can use the `who is` command');
     }
 
     const userName = response.match[1];

--- a/src/scripts/my_id.script.ts
+++ b/src/scripts/my_id.script.ts
@@ -23,9 +23,14 @@ export default (robot: Robot) => {
   });
 
   robot.respond(/whois (.+)/i, (response) => {
-    const userName = response.match[1];
     const dataStore = robot.adapter.client.rtm.dataStore;
 
+    const userId = response.envelope.user.id;
+    if (!dataStore.getUserById(userId).is_admin) {
+      return response.reply('Only admins can use the `whois` command');
+    }
+
+    const userName = response.match[1];
     const user = dataStore.getUserByName(userName);
 
     if (user) {

--- a/src/scripts/our_motto_is.script.ts
+++ b/src/scripts/our_motto_is.script.ts
@@ -3,17 +3,17 @@ import { RobotWithClient } from '../hackbot';
 export default (robot: RobotWithClient) => {
 
   robot.respond(/our motto is (.*)/i, response => {
-    const userId = response.message.user.id;
+    const user = robot.adapter.client.rtm.dataStore.getUserById(response.message.user.id);
     const motto = response.match[1];
 
-    robot.client.getUser(userId)
+    robot.client.getUser(user.id)
       .then(getUserResponse => {
 
         if ((!getUserResponse.ok && getUserResponse.statusCode === 404) || getUserResponse.user.team.id === undefined) {
           return response.reply(`You're not in a team! :goberserk:`);
         }
 
-        const emailAddress = robot.brain.data.users[userId].email_address;
+        const emailAddress = user.profile.email;
 
         robot.client.updateMotto(motto, getUserResponse.user.team.id, emailAddress)
           .then(updateMottoResponse => {

--- a/src/test/add_username_to_my_team.test.ts
+++ b/src/test/add_username_to_my_team.test.ts
@@ -5,7 +5,7 @@ import { UserData } from 'hubot';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
-describe.only('@hubot add @username to my team', () => {
+describe('@hubot add @username to my team', () => {
 
   let helper: Helper.Helper;
   let room: Helper.Room;

--- a/src/test/add_username_to_my_team.test.ts
+++ b/src/test/add_username_to_my_team.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
+import { SlackBotClient } from 'hubot-slack';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
@@ -17,7 +18,7 @@ describe('@hubot add @username to my team', () => {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
     dataStore = new MemoryDataStore();
-    robot.adapter.client = { rtm: { dataStore: dataStore } };
+    robot.adapter.client = <SlackBotClient> { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {

--- a/src/test/add_username_to_my_team.test.ts
+++ b/src/test/add_username_to_my_team.test.ts
@@ -2,19 +2,25 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
 import { UserData } from 'hubot';
+import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
-describe('@hubot add @username to my team', () => {
+describe.only('@hubot add @username to my team', () => {
 
   let helper: Helper.Helper;
   let room: Helper.Room;
   let robot: RobotWithClient;
+  let dataStore: MemoryDataStore;
 
   before(() => helper = new Helper('../index.js'));
 
   function setUp() {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
+    dataStore = new MemoryDataStore();
+    robot.adapter.client = {
+      rtm: { dataStore: dataStore },
+    };
   }
 
   function tearDown() {
@@ -26,7 +32,7 @@ describe('@hubot add @username to my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let otherUserId: string;
     let otherUserUsername: string;
@@ -36,7 +42,7 @@ describe('@hubot add @username to my team', () => {
     let addUserToTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
+      userName = 'micah';
       userEmail = 'micah.micah~micah';
       otherUserId = 'polly';
       otherUserUsername = 'abcdefghijklmnopqrstuvwxyz.-_0123456789';
@@ -44,82 +50,8 @@ describe('@hubot add @username to my team', () => {
       existingTeamName = 'Ocean Mongrels';
 
       getUserStub = sinon.stub(robot.client, 'getUser');
-      getUserStub.withArgs(userId).returns(Promise.resolve({
-        ok: true,
-        user: {
-          team: {
-            id: existingTeamId,
-            name: existingTeamName,
-          },
-        },
-      }));
-
       getUserStub
-        .withArgs(otherUserId)
-        .returns(Promise.resolve({
-          ok: true,
-          statusCode: 200,
-        }));
-
-      addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({ ok: true }));
-
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
-
-      robot.brain.data.users[otherUserId] = <UserData> {
-        id: otherUserId,
-        name: otherUserUsername,
-      };
-
-      return room.user.say(userId, `@hubot add @${otherUserUsername} to my team`);
-    });
-
-    it('should get the current user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
-    });
-
-    it('should get the other user', () => {
-      expect(getUserStub).to.have.been.calledWith(otherUserId);
-    });
-
-    it('should add the other user to the team', () => {
-      expect(addUserToTeamStub).to.have.been.calledWith(existingTeamId, otherUserId, userEmail);
-    });
-
-    it('should tell the user that the command has completed', () => {
-      expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername} to my team`],
-        ['hubot', `@${userId} Done!`],
-      ]);
-    });
-  });
-
-  describe('when username has a trailing space', () => {
-
-    before(setUp);
-    after(tearDown);
-
-    let userId: string;
-    let userEmail: string;
-    let otherUserId: string;
-    let otherUserUsername: string;
-    let existingTeamId: string;
-    let existingTeamName: string;
-    let getUserStub: sinon.SinonStub;
-    let addUserToTeamStub: sinon.SinonStub;
-
-    before(() => {
-      userId = 'micah';
-      userEmail = 'micah.micah~micah';
-      otherUserId = 'polly';
-      otherUserUsername = 'pollygrafanaasa';
-      existingTeamId = 'ocean-mongrels';
-      existingTeamName = 'Ocean Mongrels';
-
-      getUserStub = sinon.stub(robot.client, 'getUser');
-      getUserStub
-        .withArgs(userId)
+        .withArgs(userName)
         .returns(Promise.resolve({
           ok: true,
           user: {
@@ -139,20 +71,14 @@ describe('@hubot add @username to my team', () => {
 
       addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({ ok: true }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
 
-      robot.brain.data.users[otherUserId] = <UserData> {
-        id: otherUserId,
-        name: otherUserUsername,
-      };
-
-      return room.user.say(userId, `@hubot add @${otherUserUsername}  to my team`);
+      return room.user.say(userName, `@hubot add @${otherUserUsername}   to my team`);
     });
 
     it('should get the current user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should get the other user', () => {
@@ -165,8 +91,8 @@ describe('@hubot add @username to my team', () => {
 
     it('should tell the user that the command has completed', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername}  to my team`],
-        ['hubot', `@${userId} Done!`],
+        [userName, `@hubot add @${otherUserUsername}   to my team`],
+        ['hubot', `@${userName} Done!`],
       ]);
     });
   });
@@ -176,24 +102,18 @@ describe('@hubot add @username to my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
-    let userEmail: string;
-    let otherUserId: string;
+    let userName: string;
     let otherUserUsername: string;
-    let existingTeamId: string;
-    let existingTeamName: string;
-    let getUserStub: sinon.SinonStub;
-    let addUserToTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
-      userEmail = 'micah.micah~micah';
-      otherUserId = 'polly';
+      userName = 'micah';
+      const userEmail = 'micah.micah~micah';
+      const otherUserId = 'polly';
       otherUserUsername = 'pollygrafanaasa';
-      existingTeamId = 'ocean-mongrels';
-      existingTeamName = 'Ocean Mongrels';
+      const existingTeamId = 'ocean-mongrels';
+      const existingTeamName = 'Ocean Mongrels';
 
-      getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
+      sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: true,
         user: {
           team: {
@@ -203,26 +123,21 @@ describe('@hubot add @username to my team', () => {
         },
       }));
 
-      addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({
+      sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({
         ok: false,
         statusCode: 403,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
 
-      robot.brain.data.users[otherUserId] = <UserData> {
-        name: otherUserUsername,
-      };
-
-      return room.user.say(userId, `@hubot add @${otherUserUsername} to my team`);
+      return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
 
     it('should tell the user that they do not have permission', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername} to my team`],
-        ['hubot', `@${userId} Sorry, you don't have permission to add people to your team.`],
+        [userName, `@hubot add @${otherUserUsername} to my team`],
+        ['hubot', `@${userName} Sorry, you don't have permission to add people to your team.`],
       ]);
     });
   });
@@ -232,34 +147,29 @@ describe('@hubot add @username to my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
-    let userEmail: string;
+    let userName: string;
     let otherUserUsername: string;
-    let getUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
-      userEmail = 'micah.micah~micah';
+      userName = 'micah';
       otherUserUsername = 'pollygrafanaasa';
 
-      getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
+      sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: true,
         user: {
           team: {},
         },
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName } as User);
 
-      return room.user.say(userId, `@hubot add @${otherUserUsername} to my team`);
+      return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
 
     it('shouldtell the user that they are not in a team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername} to my team`],
-        ['hubot', `@${userId} I would, but you're not in a team...`],
+        [userName, `@hubot add @${otherUserUsername} to my team`],
+        ['hubot', `@${userName} I would, but you're not in a team...`],
       ]);
     });
   });
@@ -269,7 +179,7 @@ describe('@hubot add @username to my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let otherUserId: string;
     let otherUserUsername: string;
@@ -280,7 +190,7 @@ describe('@hubot add @username to my team', () => {
     let addUserToTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
+      userName = 'micah';
       userEmail = 'micah.micah~micah';
       otherUserId = 'polly';
       otherUserUsername = 'pollygrafanaasa';
@@ -288,7 +198,7 @@ describe('@hubot add @username to my team', () => {
       existingTeamName = 'Ocean Mongrels';
 
       getUserStub = sinon.stub(robot.client, 'getUser');
-      getUserStub.withArgs(userId).returns(Promise.resolve({
+      getUserStub.withArgs(userName).returns(Promise.resolve({
         ok: true,
         user: {
           team: {
@@ -304,23 +214,16 @@ describe('@hubot add @username to my team', () => {
       }));
 
       createUserStub = sinon.stub(robot.client, 'createUser').returns(Promise.resolve({ ok: true }));
-
       addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({ ok: true }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
 
-      robot.brain.data.users[otherUserId] = <UserData> {
-        id: otherUserId,
-        name: otherUserUsername,
-      };
-
-      return room.user.say(userId, `@hubot add @${otherUserUsername} to my team`);
+      return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
 
     it('should get the current user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should get the other user', () => {
@@ -337,8 +240,8 @@ describe('@hubot add @username to my team', () => {
 
     it('should tell the user that the command has completed', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername} to my team`],
-        ['hubot', `@${userId} Done!`],
+        [userName, `@hubot add @${otherUserUsername} to my team`],
+        ['hubot', `@${userName} Done!`],
       ]);
     });
   });
@@ -348,25 +251,19 @@ describe('@hubot add @username to my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
-    let userEmail: string;
-    let otherUserId: string;
+    let userName: string;
     let otherUserUsername: string;
-    let existingTeamId: string;
-    let existingTeamName: string;
-    let getUserStub: sinon.SinonStub;
-    let addUserToTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
-      userEmail = 'micah.micah~micah';
-      otherUserId = 'polly';
+      userName = 'micah';
+      const userEmail = 'micah.micah~micah';
+      const otherUserId = 'polly';
       otherUserUsername = 'pollygrafanaasa';
-      existingTeamId = 'ocean-mongrels';
-      existingTeamName = 'Ocean Mongrels';
+      const existingTeamId = 'ocean-mongrels';
+      const existingTeamName = 'Ocean Mongrels';
 
-      getUserStub = sinon.stub(robot.client, 'getUser');
-      getUserStub.withArgs(userId).returns(Promise.resolve({
+      const getUserStub = sinon.stub(robot.client, 'getUser');
+      getUserStub.withArgs(userName).returns(Promise.resolve({
         ok: true,
         user: {
           team: {
@@ -381,27 +278,21 @@ describe('@hubot add @username to my team', () => {
         statusCode: 200,
       }));
 
-      addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({
+      sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({
         ok: false,
         statusCode: 400,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
 
-      robot.brain.data.users[otherUserId] = <UserData> {
-        id: otherUserId,
-        name: otherUserUsername,
-      };
-
-      return room.user.say(userId, `@hubot add @${otherUserUsername} to my team`);
+      return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
 
     it('should tell the user that the other user may already be in a team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot add @${otherUserUsername} to my team`],
-        ['hubot', `@${userId} Sorry, ${otherUserUsername} is already in another team and must leave that team first.`],
+        [userName, `@hubot add @${otherUserUsername} to my team`],
+        ['hubot', `@${userName} Sorry, ${otherUserUsername} is already in another team and must leave that team first.`],
       ]);
     });
   });

--- a/src/test/add_username_to_my_team.test.ts
+++ b/src/test/add_username_to_my_team.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
-import { UserData } from 'hubot';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
@@ -18,9 +17,7 @@ describe('@hubot add @username to my team', () => {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
     dataStore = new MemoryDataStore();
-    robot.adapter.client = {
-      rtm: { dataStore: dataStore },
-    };
+    robot.adapter.client = { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {
@@ -71,8 +68,12 @@ describe('@hubot add @username to my team', () => {
 
       addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({ ok: true }));
 
-      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
-      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName')
+        .withArgs(otherUserUsername)
+        .returns({ id: otherUserId, name: otherUserUsername } as User);
 
       return room.user.say(userName, `@hubot add @${otherUserUsername}   to my team`);
     });
@@ -128,8 +129,12 @@ describe('@hubot add @username to my team', () => {
         statusCode: 403,
       }));
 
-      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
-      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName')
+        .withArgs(otherUserUsername)
+        .returns({ id: otherUserId, name: otherUserUsername } as User);
 
       return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
@@ -216,8 +221,12 @@ describe('@hubot add @username to my team', () => {
       createUserStub = sinon.stub(robot.client, 'createUser').returns(Promise.resolve({ ok: true }));
       addUserToTeamStub = sinon.stub(robot.client, 'addUserToTeam').returns(Promise.resolve({ ok: true }));
 
-      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
-      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName')
+        .withArgs(otherUserUsername)
+        .returns({ id: otherUserId, name: otherUserUsername } as User);
 
       return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });
@@ -283,8 +292,12 @@ describe('@hubot add @username to my team', () => {
         statusCode: 400,
       }));
 
-      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
-      sinon.stub(dataStore, 'getUserByName').withArgs(otherUserUsername).returns({ id: otherUserId, name: otherUserUsername } as UserData);
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
+      sinon.stub(dataStore, 'getUserByName')
+        .withArgs(otherUserUsername)
+        .returns({ id: otherUserId, name: otherUserUsername } as User);
 
       return room.user.say(userName, `@hubot add @${otherUserUsername} to my team`);
     });

--- a/src/test/create_team.test.ts
+++ b/src/test/create_team.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
+import { SlackBotClient } from 'hubot-slack';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
@@ -17,7 +18,7 @@ describe('@hubot create team X', () => {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
     dataStore = new MemoryDataStore();
-    robot.adapter.client = { rtm: { dataStore: dataStore } };
+    robot.adapter.client = <SlackBotClient> { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {

--- a/src/test/create_team.test.ts
+++ b/src/test/create_team.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
-import { UserData } from 'hubot';
+import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
 describe('@hubot create team X', () => {
@@ -9,12 +9,15 @@ describe('@hubot create team X', () => {
   let helper: Helper.Helper;
   let room: Helper.Room;
   let robot: RobotWithClient;
+  let dataStore: MemoryDataStore;
 
   before(() => helper = new Helper('../index.js'));
 
   function setUp() {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
+    dataStore = new MemoryDataStore();
+    robot.adapter.client = { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {
@@ -26,46 +29,44 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let teamName: string;
     let getUserStub: sinon.SinonStub;
     let createTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'bob';
+      userName = 'bob';
       userEmail = 'pinny.espresso@food.co';
       teamName = 'Pineapple Express';
 
       getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: true,
         user: {
-          id: userId,
+          id: userName,
           team: {},
         },
       }));
 
       createTeamStub = sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({ ok: true }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should fetch the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should create the team', () => {
-      expect(createTeamStub).to.have.been.calledWith(teamName, userId, userEmail);
+      expect(createTeamStub).to.have.been.calledWith(teamName, userName, userEmail);
     });
 
     it('should welcome the user to the team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Welcome to team ${teamName}!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Welcome to team ${teamName}!`],
       ]);
     });
   });
@@ -75,41 +76,36 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
-    let userEmail: string;
+    let userName: string;
     let teamName: string;
-    let getUserStub: sinon.SinonStub;
-    let createTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'bob';
-      userEmail = 'pinny.espresso@food.co';
+      userName = 'bob';
+      const userEmail = 'pinny.espresso@food.co';
       teamName = 'Pineapple Express';
 
-      getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
+      sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: true,
         user: {
-          id: userId,
+          id: userName,
           team: {},
         },
       }));
 
-      createTeamStub = sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({
+      sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({
         ok: false,
         statusCode: 403,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should not welcome the user to the team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Sorry, you don't have permission to create a team.`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Sorry, you don't have permission to create a team.`],
       ]);
     });
   });
@@ -119,18 +115,15 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
-    let teamId: string;
+    let userName: string;
     let teamName: string;
-    let existingTeamId: string;
     let existingTeamName: string;
     let getUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'barry';
-      teamId = 'bodaz';
+      userName = 'barry';
       teamName = 'Bobby Dazzlers';
-      existingTeamId = 'pineapple-express';
+      const existingTeamId = 'pineapple-express';
       existingTeamName = 'Pineapple Express';
 
       getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
@@ -143,21 +136,19 @@ describe('@hubot create team X', () => {
         },
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'sadadd',
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: {} } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should fetch the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should tell the user that they cannot be in more than one team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} You're already a member of ${existingTeamName}!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} You're already a member of ${existingTeamName}!`],
       ]);
     });
   });
@@ -167,14 +158,14 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let teamName: string;
     let getUserStub: sinon.SinonStub;
     let createTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'jerry';
+      userName = 'jerry';
       userEmail = 'jerry@jerry.jerry';
       teamName = 'Top Bants';
 
@@ -190,25 +181,23 @@ describe('@hubot create team X', () => {
         statusCode: 409,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should fetch the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should try to create the team', () => {
-      expect(createTeamStub).to.have.been.calledWith(teamName, userId, userEmail);
+      expect(createTeamStub).to.have.been.calledWith(teamName, userName, userEmail);
     });
 
     it('should tell the user that the team already exists', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot create team Top Bants'],
-        ['hubot', `@${userId} Sorry, but that team already exists!`],
+        [userName, '@hubot create team Top Bants'],
+        ['hubot', `@${userName} Sorry, but that team already exists!`],
       ]);
     });
   });
@@ -218,7 +207,7 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let teamName: string;
     let getUserStub: sinon.SinonStub;
@@ -226,7 +215,7 @@ describe('@hubot create team X', () => {
     let createTeamStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       userEmail = 'sarah@sarah.sarah';
       teamName = 'Pineapple Express';
 
@@ -236,32 +225,29 @@ describe('@hubot create team X', () => {
       }));
 
       createUserStub = sinon.stub(robot.client, 'createUser').returns(Promise.resolve({ ok: true }));
-
       createTeamStub = sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({ ok: true }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should fetch the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should create the user', () => {
-      expect(createUserStub).to.have.been.calledWith(userId, userId, userEmail);
+      expect(createUserStub).to.have.been.calledWith(userName, userName, userEmail);
     });
 
     it('should create the team', () => {
-      expect(createTeamStub).to.have.been.calledWith(teamName, userId, userEmail);
+      expect(createTeamStub).to.have.been.calledWith(teamName, userName, userEmail);
     });
 
     it('should welcome the new user to the new team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Welcome to team ${teamName}!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Welcome to team ${teamName}!`],
       ]);
     });
   });
@@ -271,14 +257,14 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let teamName: string;
     let getUserStub: sinon.SinonStub;
     let createUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       userEmail = 'sarah@sarah.sarah';
       teamName = 'Pineapple Express';
 
@@ -292,17 +278,15 @@ describe('@hubot create team X', () => {
         statusCode: 403,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should welcome the new user to the new team', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Sorry, you don\'t have permission to create a team.`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Sorry, you don\'t have permission to create a team.`],
       ]);
     });
   });
@@ -312,14 +296,14 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let teamName: string;
     let getUserStub: sinon.SinonStub;
     let createUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'hannah';
+      userName = 'hannah';
       userEmail = 'an.email.address';
       teamName = ':melon:';
 
@@ -333,25 +317,23 @@ describe('@hubot create team X', () => {
         statusCode: 54,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById').withArgs(userName).returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should fetch the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should create the user', () => {
-      expect(createUserStub).to.have.been.calledWith(userId, userId);
+      expect(createUserStub).to.have.been.calledWith(userName, userName);
     });
 
     it('should tell the user that their user account could not be created', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Sorry, I can't create your user account :frowning:`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Sorry, I can't create your user account :frowning:`],
       ]);
     });
   });
@@ -361,28 +343,28 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Whizzbang';
 
       sinon.stub(robot.client, 'getUser').returns(Promise.resolve({ ok: false, statusCode: 404 }));
       sinon.stub(robot.client, 'createUser').returns(Promise.resolve({ ok: true, statusCode: 201 }));
       sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({ ok: false, statusCode: 503 }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'another.email.address',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'another.email.address' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should tell the user that the team could not be created', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Sorry, I can't create your team :frowning:`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Sorry, I can't create your team :frowning:`],
       ]);
     });
   });
@@ -392,11 +374,11 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Whizzbang';
 
       sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
@@ -408,17 +390,17 @@ describe('@hubot create team X', () => {
 
       sinon.stub(robot.client, 'createTeam').returns(Promise.resolve({ ok: false, statusCode: 503 }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'some.email.address',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'some.email.address' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should tell the user that the team could not be created', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} Sorry, I can't create your team :frowning:`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} Sorry, I can't create your team :frowning:`],
       ]);
     });
   });
@@ -428,24 +410,24 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
     let error: Error;
     let emitStub: sinon.SinonSpy;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Rosie';
       error = new Error('when getUser fails');
 
       sinon.stub(robot.client, 'getUser').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'bark',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'bark' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should emit the error', () => {
@@ -454,8 +436,8 @@ describe('@hubot create team X', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} I'm sorry, there appears to be a big problem!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} I'm sorry, there appears to be a big problem!`],
       ]);
     });
   });
@@ -465,13 +447,13 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
     let error: Error;
     let emitStub: sinon.SinonSpy;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Rosie';
       error = new Error('when user does not exist and createUser fails');
 
@@ -479,11 +461,11 @@ describe('@hubot create team X', () => {
       sinon.stub(robot.client, 'createUser').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'bark',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'bark' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should emit the error', () => {
@@ -492,8 +474,8 @@ describe('@hubot create team X', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} I'm sorry, there appears to be a big problem!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} I'm sorry, there appears to be a big problem!`],
       ]);
     });
   });
@@ -503,13 +485,13 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
     let error: Error;
     let emitStub: sinon.SinonSpy;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Rosie';
       error = new Error('when created user and createTeam fails');
 
@@ -518,11 +500,11 @@ describe('@hubot create team X', () => {
       sinon.stub(robot.client, 'createTeam').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'bark',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'bark' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should emit the error', () => {
@@ -531,8 +513,8 @@ describe('@hubot create team X', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} I'm sorry, there appears to be a big problem!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} I'm sorry, there appears to be a big problem!`],
       ]);
     });
   });
@@ -542,13 +524,13 @@ describe('@hubot create team X', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let teamName: string;
     let error: Error;
     let emitStub: sinon.SinonSpy;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       teamName = 'Rosie';
       error = new Error('when user already exists and createTeam fails');
 
@@ -556,11 +538,11 @@ describe('@hubot create team X', () => {
       sinon.stub(robot.client, 'createTeam').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'bark',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'bark' } } as User);
 
-      return room.user.say(userId, `@hubot create team ${teamName}`);
+      return room.user.say(userName, `@hubot create team ${teamName}`);
     });
 
     it('should emit the error', () => {
@@ -569,8 +551,8 @@ describe('@hubot create team X', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        [userId, `@hubot create team ${teamName}`],
-        ['hubot', `@${userId} I'm sorry, there appears to be a big problem!`],
+        [userName, `@hubot create team ${teamName}`],
+        ['hubot', `@${userName} I'm sorry, there appears to be a big problem!`],
       ]);
     });
   });

--- a/src/test/leave_my_team.test.ts
+++ b/src/test/leave_my_team.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
+import { SlackBotClient } from 'hubot-slack';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
@@ -17,7 +18,7 @@ describe('@hubot leave my team', () => {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
     dataStore = new MemoryDataStore();
-    robot.adapter.client = { rtm: { dataStore: dataStore } };
+    robot.adapter.client = <SlackBotClient> { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {

--- a/src/test/leave_my_team.test.ts
+++ b/src/test/leave_my_team.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
-import { UserData } from 'hubot';
+import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
 describe('@hubot leave my team', () => {
@@ -9,12 +9,15 @@ describe('@hubot leave my team', () => {
   let helper: Helper.Helper;
   let room: Helper.Room;
   let robot: RobotWithClient;
+  let dataStore: MemoryDataStore;
 
   before(() => helper = new Helper('../index.js'));
 
   function setUp() {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
+    dataStore = new MemoryDataStore();
+    robot.adapter.client = { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {
@@ -26,7 +29,7 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let existingTeamId: string;
     let existingTeamName: string;
@@ -34,7 +37,7 @@ describe('@hubot leave my team', () => {
     let removeTeamMemberStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
+      userName = 'micah';
       userEmail = 'micah.micah~micah';
       existingTeamId = 'ocean-mongrels';
       existingTeamName = 'Ocean Mongrels';
@@ -51,25 +54,25 @@ describe('@hubot leave my team', () => {
 
       removeTeamMemberStub = sinon.stub(robot.client, 'removeTeamMember').returns(Promise.resolve({ ok: true }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, '@hubot leave my team');
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should get the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should update the team, excluding the current user in the member list', () => {
-      expect(removeTeamMemberStub).to.have.been.calledWith(existingTeamId, userId, userEmail);
+      expect(removeTeamMemberStub).to.have.been.calledWith(existingTeamId, userName, userEmail);
     });
 
     it('should tell the user that they have left the team', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot leave my team'],
-        ['hubot', `@${userId} OK, you've been removed from team "${existingTeamName}"`],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} OK, you've been removed from team "${existingTeamName}"`],
       ]);
     });
   });
@@ -79,7 +82,7 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let userEmail: string;
     let existingTeamId: string;
     let existingTeamName: string;
@@ -87,7 +90,7 @@ describe('@hubot leave my team', () => {
     let removeTeamMemberStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'micah';
+      userName = 'micah';
       userEmail = 'micah.micah~micah';
       existingTeamId = 'ocean-mongrels';
       existingTeamName = 'Ocean Mongrels';
@@ -107,17 +110,17 @@ describe('@hubot leave my team', () => {
         statusCode: 403,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: userEmail,
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
 
-      return room.user.say(userId, '@hubot leave my team');
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should tell the user that they have left the team', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot leave my team'],
-        ['hubot', `@${userId} Sorry, you don't have permission to leave your team.`],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} Sorry, you don't have permission to leave your team.`],
       ]);
     });
   });
@@ -127,11 +130,11 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let getUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
 
       getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: true,
@@ -142,21 +145,21 @@ describe('@hubot leave my team', () => {
         },
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'asdlkjalkdsjas',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName } as User);
 
-      return room.user.say(userId, '@hubot leave my team');
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should get the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should tell the user that they are not in a team', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot leave my team'],
-        ['hubot', `@${userId} You're not in a team! :goberserk:`],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} You're not in a team! :goberserk:`],
       ]);
     });
   });
@@ -166,32 +169,32 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let getUserStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
 
       getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
         ok: false,
         statusCode: 404,
       }));
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'sdfsfdsfsdf',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'sdfsfdsfsdf' } } as User);
 
-      return room.user.say(userId, '@hubot leave my team');
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should get the user', () => {
-      expect(getUserStub).to.have.been.calledWith(userId);
+      expect(getUserStub).to.have.been.calledWith(userName);
     });
 
     it('should tell the user that they are not in a team', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot leave my team'],
-        ['hubot', `@${userId} You're not in a team! :goberserk:`],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} You're not in a team! :goberserk:`],
       ]);
     });
   });
@@ -201,16 +204,22 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
+    let userName: string;
     let error: Error;
     let emitStub: sinon.SinonStub;
 
     before(() => {
+      userName = 'sarah';
       error = new Error('when getUser fails');
 
       sinon.stub(robot.client, 'getUser').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      return room.user.say('sarah', '@hubot leave my team');
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName } as User);
+
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should emit the error', () => {
@@ -219,8 +228,8 @@ describe('@hubot leave my team', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        ['sarah', '@hubot leave my team'],
-        ['hubot', '@sarah I\'m sorry, there appears to be a big problem!'],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} I'm sorry, there appears to be a big problem!`],
       ]);
     });
   });
@@ -230,12 +239,12 @@ describe('@hubot leave my team', () => {
     before(setUp);
     after(tearDown);
 
-    let userId: string;
+    let userName: string;
     let error: Error;
     let emitStub: sinon.SinonStub;
 
     before(() => {
-      userId = 'sarah';
+      userName = 'sarah';
       error = new Error('when removeTeamMember fails');
 
       sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
@@ -248,11 +257,11 @@ describe('@hubot leave my team', () => {
       sinon.stub(robot.client, 'removeTeamMember').returns(Promise.reject(error));
       emitStub = sinon.stub(robot, 'emit');
 
-      robot.brain.data.users[userId] = <UserData> {
-        email_address: 'sdfsfdsfsdf',
-      };
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: 'sdfsfdsfsdf' } } as User);
 
-      return room.user.say(userId, '@hubot leave my team');
+      return room.user.say(userName, '@hubot leave my team');
     });
 
     it('should emit the error', () => {
@@ -261,8 +270,8 @@ describe('@hubot leave my team', () => {
 
     it('should tell the user that there is a problem', () => {
       expect(room.messages).to.eql([
-        [userId, '@hubot leave my team'],
-        ['hubot', `@${userId} I\'m sorry, there appears to be a big problem!`],
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} I\'m sorry, there appears to be a big problem!`],
       ]);
     });
   });

--- a/src/test/our_motto_is.test.ts
+++ b/src/test/our_motto_is.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RobotWithClient } from '../hackbot';
+import { SlackBotClient } from 'hubot-slack';
 import { MemoryDataStore, User } from '@slack/client';
 import * as Helper from 'hubot-test-helper';
 
@@ -17,7 +18,7 @@ describe('@hubot our motto is', () => {
     room = helper.createRoom();
     robot = <RobotWithClient> room.robot;
     dataStore = new MemoryDataStore();
-    robot.adapter.client = { rtm: { dataStore: dataStore } };
+    robot.adapter.client = <SlackBotClient> { rtm: { dataStore: dataStore } };
   }
 
   function tearDown() {


### PR DESCRIPTION
Basically remove the use of the brain for user information and use the slack adapter client's data store.
Also pads out some typings which will be pulled out at some point.

Fixes #16 
