### PR TITLE
Delete team when leaving own team and only member left

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -74,6 +74,22 @@ export default class Client {
     });
   }
 
+  public removeTeam(teamId: string, emailAddress: string) {
+    return new Promise<ApiResponse>((resolve, reject) => {
+      this.createClient(`/teams/${teamId}`, { auth: this.getAuth(emailAddress) })
+        .delete('')((err, res) => {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve({
+            ok: res.statusCode === 204,
+            statusCode: res.statusCode,
+          });
+        });
+    });
+  }
+
   public createUser(userId: string, userName: string, emailAddress: string) {
     return new Promise<ApiResponse>((resolve, reject) => {
       const body = JSON.stringify({

--- a/src/scripts/leave_my_team.script.ts
+++ b/src/scripts/leave_my_team.script.ts
@@ -13,14 +13,22 @@ export default (robot: AugmentedRobot) => {
     const emailAddress = user.profile.email;
 
     const removeTeamMemberResponse = await robot.client.removeTeamMember(res.user.team.id, user.id, emailAddress);
-    if (removeTeamMemberResponse.ok) {
-      return response.reply(`OK, you've been removed from team "${res.user.team.name}"`);
-    }
+
     if (removeTeamMemberResponse.statusCode === 403) {
       return response.reply(`Sorry, you don't have permission to leave your team.`);
     }
+    if (!removeTeamMemberResponse.ok) {
+      response.reply(`Sorry, I tried, but something went wrong.`);
+    }
 
-    response.reply(`Sorry, I tried, but something went wrong.`);
+    if (res.user.team.members && res.user.team.members.length === 1) {
+      const removeTeamResponse = await robot.client.removeTeam(res.user.team.id, emailAddress);
+      if (removeTeamResponse.ok) {
+        return response.reply(`OK, you've been removed from team "${res.user.team.name}" and the team has been deleted.`);
+      }
+    }
+
+    return response.reply(`OK, you've been removed from team "${res.user.team.name}"`);
   });
 
 };

--- a/src/scripts/leave_my_team.script.ts
+++ b/src/scripts/leave_my_team.script.ts
@@ -21,11 +21,9 @@ export default (robot: AugmentedRobot) => {
       response.reply(`Sorry, I tried, but something went wrong.`);
     }
 
-    if (res.user.team.members && res.user.team.members.length === 1) {
-      const removeTeamResponse = await robot.client.removeTeam(res.user.team.id, emailAddress);
-      if (removeTeamResponse.ok) {
-        return response.reply(`OK, you've been removed from team "${res.user.team.name}" and the team has been deleted.`);
-      }
+    const removeTeamResponse = await robot.client.removeTeam(res.user.team.id, emailAddress);
+    if (removeTeamResponse.ok) {
+      return response.reply(`OK, you've been removed from team "${res.user.team.name}" and the team has been deleted.`);
     }
 
     return response.reply(`OK, you've been removed from team "${res.user.team.name}"`);

--- a/src/test/leave_my_team.test.ts
+++ b/src/test/leave_my_team.test.ts
@@ -78,6 +78,69 @@ describe('@hubot leave my team', () => {
     });
   });
 
+  describe('when in a team and only member of the team', () => {
+
+    before(setUp);
+    after(tearDown);
+
+    let userName: string;
+    let userEmail: string;
+    let existingTeamId: string;
+    let existingTeamName: string;
+    let getUserStub: sinon.SinonStub;
+    let removeTeamMemberStub: sinon.SinonStub;
+    let removeTeamStub: sinon.SinonStub;
+
+    before(() => {
+      userName = 'micah';
+      userEmail = 'micah.micah~micah';
+      existingTeamId = 'ocean-mongrels';
+      existingTeamName = 'Ocean Mongrels';
+
+      getUserStub = sinon.stub(robot.client, 'getUser').returns(Promise.resolve({
+        ok: true,
+        user: {
+          team: {
+            id: existingTeamId,
+            name: existingTeamName,
+            members: [{
+              name: 'a',
+            }],
+          },
+        },
+      }));
+
+      removeTeamMemberStub = sinon.stub(robot.client, 'removeTeamMember').returns(Promise.resolve({ ok: true }));
+
+      removeTeamStub = sinon.stub(robot.client, 'removeTeam').returns(Promise.resolve({ ok: true }));
+
+      sinon.stub(dataStore, 'getUserById')
+        .withArgs(userName)
+        .returns({ id: userName, profile: { email: userEmail } } as User);
+
+      return room.user.say(userName, '@hubot leave my team');
+    });
+
+    it('should get the user', () => {
+      expect(getUserStub).to.have.been.calledWith(userName);
+    });
+
+    it('should update the team, excluding the current user in the member list', () => {
+      expect(removeTeamMemberStub).to.have.been.calledWith(existingTeamId, userName, userEmail);
+    });
+
+    it('should delete the team', () => {
+      expect(removeTeamStub).to.have.been.calledWith(existingTeamId);
+    });
+
+    it('should tell the user that they have left the team and that the team has been deleted', () => {
+      expect(room.messages).to.eql([
+        [userName, '@hubot leave my team'],
+        ['hubot', `@${userName} OK, you've been removed from team "${existingTeamName}" and the team has been deleted.`],
+      ]);
+    });
+  });
+
   describe('when not a registered attendee', () => {
 
     before(setUp);

--- a/src/test/leave_my_team.test.ts
+++ b/src/test/leave_my_team.test.ts
@@ -36,6 +36,7 @@ describe('@hubot leave my team', () => {
     let existingTeamName: string;
     let getUserStub: sinon.SinonStub;
     let removeTeamMemberStub: sinon.SinonStub;
+    let removeTeamStub: sinon.SinonStub;
 
     before(() => {
       userName = 'micah';
@@ -54,6 +55,8 @@ describe('@hubot leave my team', () => {
       }));
 
       removeTeamMemberStub = sinon.stub(robot.client, 'removeTeamMember').returns(Promise.resolve({ ok: true }));
+
+      removeTeamStub = sinon.stub(robot.client, 'removeTeam').returns(Promise.resolve({ ok: false }));
 
       sinon.stub(dataStore, 'getUserById')
         .withArgs(userName)
@@ -103,9 +106,6 @@ describe('@hubot leave my team', () => {
           team: {
             id: existingTeamId,
             name: existingTeamName,
-            members: [{
-              name: 'a',
-            }],
           },
         },
       }));


### PR DESCRIPTION
Connects #2

Since the API does return a 400 if the team is non-empty I don''t know if you'd rather me always try and delete the team instead of checking the members list? 
